### PR TITLE
Improved email regex

### DIFF
--- a/core/components/emo/model/emo/emo.class.php
+++ b/core/components/emo/model/emo/emo.class.php
@@ -230,10 +230,7 @@ class Emo
         }
 
         // Plain email regular expession
-        $atom = "[-!\#$%'*+/=?^_`{|}~0-9A-Za-z]+";
-        $email_left = $atom . '(?:\\.' . $atom . ')*';
-        $email_right = $atom . '(?:\\.' . $atom . ')+';
-        $emailRegex = '#(' . $email_left . '@' . $email_right . ')#iu';
+        $emailRegex = '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6})/';
 
         // exclude form tags
         $splitEx = "#((?:<form).*?(?:</form>))#isu";

--- a/core/components/emo/model/emo/emo.class.php
+++ b/core/components/emo/model/emo/emo.class.php
@@ -229,9 +229,6 @@ class Emo
             $starttime = $mtime;
         }
 
-        // Plain email regular expession
-        $emailRegex = '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/';
-
         // exclude form tags
         $splitEx = "#((?:<form).*?(?:</form>))#isu";
         $parts = preg_split($splitEx, $content, null, PREG_SPLIT_DELIM_CAPTURE);
@@ -239,7 +236,7 @@ class Emo
         foreach ($parts as $part) {
             if (substr($part, 0, 5) != '<form') {
                 $part = preg_replace_callback('#<a[^>]*mailto:([^\'"]+)[\'"][^>]*>(.*?)</a>#ius', array($this, 'encodeLink'), $part);
-                $part = preg_replace_callback($emailRegex, array($this, 'encodeLink'), $part);
+                $part = preg_replace_callback('#([a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,})#iu', array($this, 'encodeLink'), $part);
             }
             $output .= $part;
         }

--- a/core/components/emo/model/emo/emo.class.php
+++ b/core/components/emo/model/emo/emo.class.php
@@ -230,7 +230,7 @@ class Emo
         }
 
         // Plain email regular expession
-        $emailRegex = '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6})/';
+        $emailRegex = '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,24})/';
 
         // exclude form tags
         $splitEx = "#((?:<form).*?(?:</form>))#isu";

--- a/core/components/emo/model/emo/emo.class.php
+++ b/core/components/emo/model/emo/emo.class.php
@@ -230,7 +230,7 @@ class Emo
         }
 
         // Plain email regular expession
-        $emailRegex = '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,24})/';
+        $emailRegex = '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/';
 
         // exclude form tags
         $splitEx = "#((?:<form).*?(?:</form>))#isu";


### PR DESCRIPTION
Updated the email regex to exclude URLs that contain @ symbols such as Google Map addresses. Changes support:
- Email addresses containing fullstop, underscore, hyphen and upper-case
- gTLD's up to 24 characters
- Excludes social media handles such as Twitter
